### PR TITLE
Add gradle configuration to show the println when running tests from teminal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+test {
+  testLogging.showStandardStreams = true
+
+}
+
 publish {
     userOrg = 'backpacker'
     groupId = 'com.github.backpacker'

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ compileTestKotlin {
 
 test {
   testLogging.showStandardStreams = true
-
 }
 
 publish {


### PR DESCRIPTION
I've just run ```./gradlew test``` from the terminal and I can't see any performance output, so...

With this new configuration, we can see the ```System.out.println``` outputs on the terminal

Screenshot:

<img width="1098" alt="captura de pantalla 2018-02-10 01 58 34" src="https://user-images.githubusercontent.com/6932449/36056672-ab1dd9e6-0e06-11e8-8616-496e8b125cbe.png">